### PR TITLE
fix: we should emit events always if configured that way

### DIFF
--- a/unleashandroidsdk/src/main/java/io/getunleash/android/DefaultUnleash.kt
+++ b/unleashandroidsdk/src/main/java/io/getunleash/android/DefaultUnleash.kt
@@ -182,7 +182,7 @@ class DefaultUnleash(
     override fun isEnabled(toggleName: String, defaultValue: Boolean): Boolean {
         val toggle = cache.get(toggleName)
         val enabled = toggle?.enabled ?: defaultValue
-        val impressionData = toggle?.impressionData ?: unleashConfig.forceImpressionData
+        val impressionData = unleashConfig.forceImpressionData || toggle?.impressionData ?: false
         if (impressionData) {
             emit(ImpressionEvent(toggleName, enabled, unleashContextState.value))
         }

--- a/unleashandroidsdk/src/test/java/io/getunleash/android/DefaultUnleashTest.kt
+++ b/unleashandroidsdk/src/test/java/io/getunleash/android/DefaultUnleashTest.kt
@@ -148,6 +148,61 @@ class DefaultUnleashTest : BaseTest() {
     }
 
     @Test
+    fun `configuring impression event to true at config level will emit an impression event on all features`() {
+        val unleash = DefaultUnleash(
+            androidContext = mock(Context::class.java),
+            unleashConfig = UnleashConfig.newBuilder("test-android-app")
+                .pollingStrategy.enabled(false)
+                .metricsStrategy.enabled(false)
+                .localStorageConfig.enabled(false)
+                .forceImpressionData(true)
+                .build(),
+            unleashContext = UnleashContext(userId = "123"),
+            lifecycle = mock(Lifecycle::class.java)
+        )
+
+        var ready = false
+        val impressionEvents = mutableListOf<ImpressionEvent>()
+        unleash.start(
+            eventListeners = listOf(object : UnleashReadyListener, UnleashImpressionEventListener {
+                override fun onImpression(event: ImpressionEvent) {
+                    println("Impression event received: ${event.featureName}")
+                    impressionEvents.add(event)
+                }
+
+                override fun onReady() {
+                    ready = true
+                }
+            }), bootstrap = listOf(
+                Toggle(name = "with-impression-1", enabled = true, impressionData = true),
+                Toggle(name = "with-impression-2", enabled = true, impressionData = true),
+                Toggle(name = "with-impression-3", enabled = true, impressionData = true),
+                Toggle(name = "without-impression", enabled = false)
+            )
+        )
+        await().atMost(1, TimeUnit.SECONDS).until { ready }
+
+
+        unleash.isEnabled("with-impression-1")
+        unleash.isEnabled("with-impression-2", true)
+        unleash.isEnabled("without-impression")
+        unleash.isEnabled("with-impression-3", false)
+        unleash.isEnabled("non-existing-toggle")
+
+        await().atMost(1, TimeUnit.SECONDS).until { impressionEvents.size >= 5 }
+        assertThat(impressionEvents).hasSize(5)
+        assertThat(impressionEvents)
+            .extracting("featureName")
+            .containsExactlyInAnyOrder(
+                "with-impression-1",
+                "with-impression-2",
+                "without-impression",
+                "with-impression-3",
+                "non-existing-toggle"
+            )
+    }
+
+    @Test
     fun `feature with impression event set to true will emit an impression event`() {
         val unleash = DefaultUnleash(
             androidContext = mock(Context::class.java),
@@ -189,12 +244,9 @@ class DefaultUnleashTest : BaseTest() {
 
         await().atMost(1, TimeUnit.SECONDS).until { impressionEvents.size >= 3 }
         assertThat(impressionEvents).hasSize(3)
-        for (i in 1 until 4) {
-            impressionEvents[i - 1].let {
-                assertThat(it.featureName).isEqualTo("with-impression-$i")
-                assertThat(it.enabled).isTrue()
-            }
-        }
+        assertThat(impressionEvents)
+            .extracting("featureName")
+            .containsExactlyInAnyOrder("with-impression-1", "with-impression-2", "with-impression-3")
     }
 
     @Test


### PR DESCRIPTION
Just checked that eventually the events might arrive out of order. Not sure if this would be a problem, I believe no as long as all events arrive. We have a buffer of 1000 events (maybe we should make it configurable, but I'd just wait until someone asks)