### PR TITLE
fix: sources already exist when packing

### DIFF
--- a/unleashandroidsdk/build.gradle.kts
+++ b/unleashandroidsdk/build.gradle.kts
@@ -50,7 +50,6 @@ android {
     publishing {
         multipleVariants {
             includeBuildTypeValues("debug", "release")
-            allVariants()
             withJavadocJar()
         }
     }

--- a/unleashandroidsdk/build.gradle.kts
+++ b/unleashandroidsdk/build.gradle.kts
@@ -48,10 +48,7 @@ android {
     }
 
     publishing {
-        multipleVariants {
-            includeBuildTypeValues("debug", "release")
-            withJavadocJar()
-        }
+        singleVariant("release")
     }
 }
 


### PR DESCRIPTION
Try to fix
```
file '/home/runner/work/unleash-android/unleash-android/unleashandroidsdk/src/main/java/io/getunleash/android/events/HeartbeatEvent.kt' will be copied to 'main/io/getunleash/android/events/HeartbeatEvent.kt', overwriting file '/home/runner/work/unleash-android/unleash-android/unleashandroidsdk/src/main/java/io/getunleash/android/events/HeartbeatEvent.kt', which has already been copied there.
```