### PR TITLE
fix: jacoco report proper coverage

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,3 +24,4 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           allow-empty: true
+          base-path: unleashandroidsdk/src/main/java

--- a/.github/workflows/prs.yaml
+++ b/.github/workflows/prs.yaml
@@ -22,3 +22,4 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           allow-empty: true
+          base-path: unleashandroidsdk/src/main/java


### PR DESCRIPTION
The [previous coverall report on main](https://coveralls.io/builds/68801615) was reporting a coverage of zero on DefaultUnleash despite having a lot of tests (and same with other classes and packages):
![image](https://github.com/user-attachments/assets/a10a80bd-1868-4aa0-88a9-a90e3d19d78d)


It looks like 
```
    configure<JacocoTaskExtension> {
        isIncludeNoLocationClasses = true
        excludes = listOf("jdk.internal.*")
    }
```
is required to get the reports properly. After this change this is my local report (note there are also some packages excluded which makes the coverage to raise):

![image](https://github.com/user-attachments/assets/2e984f4f-53d6-486d-96c2-3ba1efc164b4)
