### PR TITLE
chore: avoid flaky test

### DIFF
--- a/unleashandroidsdk/src/test/java/io/getunleash/android/DefaultUnleashTest.kt
+++ b/unleashandroidsdk/src/test/java/io/getunleash/android/DefaultUnleashTest.kt
@@ -296,6 +296,7 @@ class DefaultUnleashTest : BaseTest() {
                 .proxyUrl(server.url("").toString())
                 .clientKey("key-123")
                 .pollingStrategy.enabled(true)
+                .pollingStrategy.delay(10000) // delay enough so it won't trigger a new request
                 .metricsStrategy.enabled(false)
                 .localStorageConfig.enabled(false)
                 .build(),


### PR DESCRIPTION
Not sure if this would fix it, but probably the first poll is kicking in and therefore messing up with the test.
This should make sure our test is not running the poll cycle but still keeping the polling enabled