### PR TITLE
chore: migrate to moshi to reduce bundle size

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,9 +8,9 @@ androidxTestExt = "1.2.1"
 espressoCore = "3.6.1"
 appcompat = "1.7.0"
 material = "1.12.0"
+moshi = "1.15.1"
 work = "2.9.0"
 okhttp = "4.12.0"
-jackson = "2.17.2"
 assertj = "3.26.3"
 lifecycleProcess = "2.8.3"
 kotlinxCoroutinesTest = "1.8.1"
@@ -30,15 +30,13 @@ androidx-work-ktx = { group = "androidx.work", name = "work-runtime-ktx", versio
 androidx-work-testing = { group = "androidx.work", name = "work-testing", version.ref = "work" }
 androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycleProcess" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
+moshi-kotlin = { group = "com.squareup.moshi", name="moshi-kotlin", version.ref = "moshi" }
+moshi-adapters = { group = "com.squareup.moshi", name="moshi-adapters", version.ref = "moshi" }
 robolectric-test = { group = "org.robolectric", name = "robolectric", version = "4.13" }
 awaitility = { group = "org.awaitility", name = "awaitility", version = "4.2.1" }
 
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 okhttp-mockserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "okhttp" }
-jackson-databind = { group = "com.fasterxml.jackson.core", name = "jackson-databind", version.ref = "jackson" }
-jackson-core = { group = "com.fasterxml.jackson.core", name = "jackson-core", version.ref = "jackson" }
-jackson-module-kotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version.ref = "jackson" }
-jackson-datatype-jsr310 = { group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jsr310", version.ref = "jackson" }
 assertj = { group = "org.assertj", name = "assertj-core", version.ref = "assertj" }
 jsonunit = { group = "net.javacrumbs.json-unit", name = "json-unit-assertj", version.ref = "jsonunit" }
 

--- a/unleashandroidsdk/build.gradle.kts
+++ b/unleashandroidsdk/build.gradle.kts
@@ -64,10 +64,8 @@ dependencies {
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.process)
-    implementation(libs.jackson.databind)
-    implementation(libs.jackson.core)
-    implementation(libs.jackson.module.kotlin)
-    implementation(libs.jackson.datatype.jsr310)
+    implementation(libs.moshi.kotlin)
+    implementation(libs.moshi.adapters)
     api(libs.okhttp)
 
     testImplementation(libs.junit)

--- a/unleashandroidsdk/proguard-rules.pro
+++ b/unleashandroidsdk/proguard-rules.pro
@@ -20,4 +20,6 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 -keep public class io.getunleash.** { *; }
--keep class com.fasterxml.** { *; }
+-keepclasseswithmembers class * {
+    @com.squareup.moshi.* methods;
+}

--- a/unleashandroidsdk/src/main/java/io/getunleash/android/DefaultUnleash.kt
+++ b/unleashandroidsdk/src/main/java/io/getunleash/android/DefaultUnleash.kt
@@ -137,7 +137,7 @@ class DefaultUnleash(
         lifecycle.addObserver(taskManager)
         if (bootstrapFile != null && bootstrapFile.exists()) {
             Log.i(TAG, "Using provided bootstrap file")
-            Parser.jackson.readValue(bootstrapFile, ProxyResponse::class.java)?.let { state ->
+            Parser.proxyResponseAdapter.fromJson(bootstrapFile.readText())?.let { state ->
                 val toggles = state.toggles.groupBy { it.name }
                     .mapValues { (_, v) -> v.first() }
                 cache.write(UnleashState(unleashContextState.value, toggles))

--- a/unleashandroidsdk/src/main/java/io/getunleash/android/data/Parser.kt
+++ b/unleashandroidsdk/src/main/java/io/getunleash/android/data/Parser.kt
@@ -1,18 +1,66 @@
 package io.getunleash.android.data
-
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.databind.util.StdDateFormat
-import com.fasterxml.jackson.module.kotlin.KotlinFeature
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import com.squareup.moshi.adapters.Rfc3339DateJsonAdapter
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import io.getunleash.android.metrics.MetricsPayload
+import io.getunleash.android.polling.ProxyResponse
+import java.lang.reflect.Type
+import java.util.Date
 
 object Parser {
-    val jackson: ObjectMapper =
+    /*val jackson: ObjectMapper =
         jacksonObjectMapper {
             enable(KotlinFeature.NullIsSameAsDefault)
         }.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
             .setDateFormat(
                 StdDateFormat().withColonInTimeZone(true)
-            ).disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            ).disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)*/
+
+
+
+    val moshi: Moshi = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory()) // for Kotlin support
+        .add(Date::class.java, Rfc3339DateJsonAdapter().nullSafe()) // for date format
+//        .add(DefaultOnNullAdapterFactory())
+        .build()
+    val proxyResponseAdapter: JsonAdapter<ProxyResponse> = moshi.adapter(ProxyResponse::class.java)
+    val metricsBodyAdapter: JsonAdapter<MetricsPayload> = moshi.adapter(MetricsPayload::class.java)
+
+    // Define an adapter to handle null values as default
+    class DefaultOnNullAdapterFactory : JsonAdapter.Factory {
+        override fun create(
+            type: Type,
+            annotations: MutableSet<out Annotation>,
+            moshi: Moshi
+        ): JsonAdapter<*>? {
+            val rawType = Types.getRawType(type)
+            if (rawType.isAnnotationPresent(DefaultOnNull::class.java)) {
+                val delegate = moshi.nextAdapter<Any>(this, type, annotations)
+                return object : JsonAdapter<Any>() {
+                    override fun fromJson(reader: JsonReader): Any? {
+                        if (reader.peek() == JsonReader.Token.NULL) {
+                            reader.nextNull<Unit>()
+                            return rawType.getDeclaredConstructor().newInstance()
+                        }
+                        return delegate.fromJson(reader)
+                    }
+
+                    override fun toJson(writer: JsonWriter, value: Any?) {
+                        delegate.toJson(writer, value)
+                    }
+                }
+            }
+            return null
+        }
+    }
+
+    // Custom annotation to handle default values
+    @Retention(AnnotationRetention.RUNTIME)
+    @Target(AnnotationTarget.CLASS)
+    annotation class DefaultOnNull
+
 }

--- a/unleashandroidsdk/src/main/java/io/getunleash/android/data/Variant.kt
+++ b/unleashandroidsdk/src/main/java/io/getunleash/android/data/Variant.kt
@@ -1,10 +1,10 @@
 package io.getunleash.android.data
 
-import com.fasterxml.jackson.annotation.JsonProperty
+import com.squareup.moshi.Json
 
 data class Variant(
     val name: String,
     val enabled: Boolean = true,
-    @JsonProperty("feature_enabled") val featureEnabled: Boolean = false,
+    @Json(name = "feature_enabled") val featureEnabled: Boolean = false,
     val payload: Payload? = null
 )

--- a/unleashandroidsdk/src/main/java/io/getunleash/android/metrics/MetricsBucket.kt
+++ b/unleashandroidsdk/src/main/java/io/getunleash/android/metrics/MetricsBucket.kt
@@ -8,13 +8,13 @@ import java.util.concurrent.atomic.AtomicInteger
 data class EvaluationCount(
     var yes: Int,
     var no: Int,
-    val variants: ConcurrentHashMap<String, Int> = ConcurrentHashMap()
+    val variants: MutableMap<String, Int> = mutableMapOf()
 )
 
 data class Bucket(
     val start: Date,
     val stop: Date,
-    val toggles: ConcurrentHashMap<String, EvaluationCount> = ConcurrentHashMap()
+    val toggles: MutableMap<String, EvaluationCount> = mutableMapOf()
 )
 
 interface UnleashMetricsBucket {

--- a/unleashandroidsdk/src/main/java/io/getunleash/android/metrics/MetricsSender.kt
+++ b/unleashandroidsdk/src/main/java/io/getunleash/android/metrics/MetricsSender.kt
@@ -2,7 +2,7 @@ package io.getunleash.android.metrics
 
 import android.util.Log
 import io.getunleash.android.UnleashConfig
-import io.getunleash.android.data.Parser
+import io.getunleash.android.data.Parser.metricsBodyAdapter
 import io.getunleash.android.data.Variant
 import io.getunleash.android.http.Throttler
 import okhttp3.Call
@@ -51,7 +51,7 @@ class MetricsSender(
             val request = Request.Builder()
                 .headers(applicationHeaders.toHeaders())
                 .url(metricsUrl).post(
-                    Parser.jackson.writeValueAsString(payload)
+                    metricsBodyAdapter.toJson(payload)
                         .toRequestBody("application/json".toMediaType())
                 ).build()
             httpClient.newCall(request).enqueue(object : Callback {

--- a/unleashandroidsdk/src/main/java/io/getunleash/android/polling/UnleashFetcher.kt
+++ b/unleashandroidsdk/src/main/java/io/getunleash/android/polling/UnleashFetcher.kt
@@ -1,9 +1,8 @@
 package io.getunleash.android.polling
 
 import android.util.Log
-import com.fasterxml.jackson.module.kotlin.readValue
 import io.getunleash.android.UnleashConfig
-import io.getunleash.android.data.Parser
+import io.getunleash.android.data.Parser.proxyResponseAdapter
 import io.getunleash.android.data.UnleashContext
 import io.getunleash.android.data.UnleashState
 import io.getunleash.android.errors.NoBodyException
@@ -157,7 +156,7 @@ open class UnleashFetcher(
                         res.body?.use { b ->
                             try {
                                 val proxyResponse: ProxyResponse =
-                                    Parser.jackson.readValue(b.string())
+                                    proxyResponseAdapter.fromJson(b.string())!!
                                 FetchResponse(Status.SUCCESS, proxyResponse)
                             } catch (e: Exception) {
                                 // If we fail to parse, just keep data

--- a/unleashandroidsdk/src/test/java/io/getunleash/android/BaseTest.kt
+++ b/unleashandroidsdk/src/test/java/io/getunleash/android/BaseTest.kt
@@ -20,7 +20,7 @@ abstract class BaseTest {
         ShadowLog.setTimeSupplier {
             df.format(Date())
         }
-
+        System.setProperty("json-unit.libraries", "moshi")
     }
 }
 

--- a/unleashandroidsdk/src/test/java/io/getunleash/android/data/PayloadTest.kt
+++ b/unleashandroidsdk/src/test/java/io/getunleash/android/data/PayloadTest.kt
@@ -1,7 +1,8 @@
 package io.getunleash.android.data
 
-import com.fasterxml.jackson.module.kotlin.readValue
-import io.getunleash.android.polling.ProxyResponse
+import com.squareup.moshi.JsonAdapter
+import io.getunleash.android.data.Parser.moshi
+import io.getunleash.android.data.Parser.proxyResponseAdapter
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -16,27 +17,28 @@ private const val stringPayloadVariant = "{\n" +
 
 class PayloadTest {
 
+    val variantsAdapter: JsonAdapter<Variant> = moshi.adapter(Variant::class.java)
     @Test
     fun testGetValueAsString() {
-        val variant = Parser.jackson.readValue(stringPayloadVariant, Variant::class.java)
+        val variant = variantsAdapter.fromJson(stringPayloadVariant)!!
         assertThat(variant.payload?.getValueAsString()).isEqualTo("11")
     }
 
     @Test
     fun testGetValueAsNumber() {
-        val variant = Parser.jackson.readValue(stringPayloadVariant, Variant::class.java)
+        val variant = variantsAdapter.fromJson(stringPayloadVariant)!!
         assertThat(variant.payload?.getValueAsInt()).isEqualTo(11)
     }
 
     @Test
     fun testGetValueAsBool() {
-        val variant = Parser.jackson.readValue(stringPayloadVariant, Variant::class.java)
+        val variant = variantsAdapter.fromJson(stringPayloadVariant)!!
         assertThat(variant.payload?.getValueAsBoolean()).isFalse()
     }
 
     @Test
     fun `Able to parse payload value as string`() {
-        val response: ProxyResponse = Parser.jackson.readValue(TestResponses.threeToggles)
+        val response = proxyResponseAdapter.fromJson(TestResponses.threeToggles)!!
         val map = response.toggles.groupBy { it.name }.mapValues { (_, v) -> v.first() }
         val toggle = map["variantToggle"]!!
         assertThat(toggle.variant.payload!!.getValueAsString()).isEqualTo("some-text")
@@ -44,7 +46,7 @@ class PayloadTest {
 
     @Test
     fun `Able to parse payload value as integer`() {
-        val response: ProxyResponse = Parser.jackson.readValue(TestResponses.complicatedVariants)
+        val response = proxyResponseAdapter.fromJson(TestResponses.complicatedVariants)!!
         val map = response.toggles.groupBy { it.name }.mapValues { (_, v) -> v.first() }
         val toggle = map["variantToggle"]!!
         assertThat(toggle.variant.payload!!.getValueAsInt()).isEqualTo(54)
@@ -52,7 +54,7 @@ class PayloadTest {
 
     @Test
     fun `Able to parse payload value as boolean`() {
-        val response: ProxyResponse = Parser.jackson.readValue(TestResponses.complicatedVariants)
+        val response = proxyResponseAdapter.fromJson(TestResponses.complicatedVariants)!!
         val map = response.toggles.groupBy { it.name }.mapValues { (_, v) -> v.first() }
         val toggle = map["booleanVariant"]!!
         assertThat(toggle.variant.payload!!.getValueAsBoolean()).isTrue
@@ -60,7 +62,7 @@ class PayloadTest {
 
     @Test
     fun `Able to parse payload value as double`() {
-        val response: ProxyResponse = Parser.jackson.readValue(TestResponses.complicatedVariants)
+        val response = proxyResponseAdapter.fromJson(TestResponses.complicatedVariants)!!
         val map = response.toggles.groupBy { it.name }.mapValues { (_, v) -> v.first() }
         val toggle = map["doubleVariant"]!!
         assertThat(toggle.variant.payload!!.getValueAsDouble()).isEqualTo(42.0)

--- a/unleashandroidsdk/src/test/java/io/getunleash/android/data/TestResponses.kt
+++ b/unleashandroidsdk/src/test/java/io/getunleash/android/data/TestResponses.kt
@@ -1,8 +1,5 @@
 package io.getunleash.android.data
 
-import com.fasterxml.jackson.module.kotlin.readValue
-import io.getunleash.android.polling.ProxyResponse
-
 object TestResponses {
     val threeToggles = """
         {
@@ -86,8 +83,4 @@ object TestResponses {
                 ]
             }""".trimIndent()
 
-    fun String.toToggleMap(): Map<String, Toggle> {
-        val response: ProxyResponse = Parser.jackson.readValue(this)
-        return response.toggles.groupBy { it.name }.mapValues { (_, v) -> v.first() }
-    }
 }

--- a/unleashandroidsdk/src/test/java/io/getunleash/android/metrics/MetricsSenderTest.kt
+++ b/unleashandroidsdk/src/test/java/io/getunleash/android/metrics/MetricsSenderTest.kt
@@ -68,7 +68,9 @@ class MetricsSenderTest : BaseTest() {
         )!!
         assertThat(request.method).isEqualTo("POST")
         assertThat(request.path).isEqualTo("/proxy/client/metrics")
-        assertThatJson(request.body.readUtf8()) {
+        val body = request.body.readUtf8()
+        println(body)
+        assertThatJson(body) {
             node("appName").isString().isEqualTo("my-test-app")
             node("instanceId").isString().matches(".+")
             node("bucket").apply {

--- a/unleashandroidsdk/src/test/java/io/getunleash/android/metrics/MetricsSenderTest.kt
+++ b/unleashandroidsdk/src/test/java/io/getunleash/android/metrics/MetricsSenderTest.kt
@@ -68,9 +68,7 @@ class MetricsSenderTest : BaseTest() {
         )!!
         assertThat(request.method).isEqualTo("POST")
         assertThat(request.path).isEqualTo("/proxy/client/metrics")
-        val body = request.body.readUtf8()
-        println(body)
-        assertThatJson(body) {
+        assertThatJson(request.body.readUtf8()) {
             node("appName").isString().isEqualTo("my-test-app")
             node("instanceId").isString().matches(".+")
             node("bucket").apply {


### PR DESCRIPTION
Moshi is a much smaller library compared to jackson which allows us to reduce the overall bundle size