### PR TITLE
fix: variant enabled should be false by default

### DIFF
--- a/unleashandroidsdk/src/main/java/io/getunleash/android/data/Variant.kt
+++ b/unleashandroidsdk/src/main/java/io/getunleash/android/data/Variant.kt
@@ -4,7 +4,7 @@ import com.squareup.moshi.Json
 
 data class Variant(
     val name: String,
-    val enabled: Boolean = true,
+    val enabled: Boolean = false,
     @Json(name = "feature_enabled") val featureEnabled: Boolean = false,
     val payload: Payload? = null
 )


### PR DESCRIPTION
This complies with other SDKs. For reference we use NodeJS:
```typescript
const defaultVariant: IVariant = {
    name: 'disabled',
    enabled: false,
    feature_enabled: false,
};
```
