### PR TITLE
fix: when skipping a call due to throttle count one more skipped

### DIFF
--- a/unleashandroidsdk/src/main/java/io/getunleash/android/polling/UnleashFetcher.kt
+++ b/unleashandroidsdk/src/main/java/io/getunleash/android/polling/UnleashFetcher.kt
@@ -95,15 +95,7 @@ open class UnleashFetcher(
     }
 
     suspend fun refreshToggles(): ToggleResponse {
-        if (throttler.performAction()) {
-            Log.d(TAG, "Refreshing toggles")
-            val response = doFetchToggles(unleashContext.value)
-            fetcherHeartbeatFlow.emit(HeartbeatEvent(response.status, response.error?.message))
-            return response
-        }
-        Log.i(TAG, "Skipping refresh toggles due to throttling")
-        fetcherHeartbeatFlow.emit(HeartbeatEvent(Status.THROTTLED))
-        return ToggleResponse(Status.THROTTLED)
+        return this.refreshTogglesWithContext(unleashContext.value);
     }
 
     suspend fun refreshTogglesWithContext(ctx: UnleashContext): ToggleResponse {
@@ -113,6 +105,7 @@ open class UnleashFetcher(
             fetcherHeartbeatFlow.emit(HeartbeatEvent(response.status, response.error?.message))
             return response
         }
+        throttler.skipped() // count skipped requests
         Log.i(TAG, "Skipping refresh toggles due to throttling")
         fetcherHeartbeatFlow.emit(HeartbeatEvent(Status.THROTTLED))
         return ToggleResponse(Status.THROTTLED)


### PR DESCRIPTION
## About the changes
When skipping http calls due to throttling we should also count that we skipped that call so the throttler can recover. This is done in the metrics implementation: https://github.com/Unleash/unleash-android/blob/5c52d66e91e6ffa9c2d1ba5306a8d6663ae00c44/unleashandroidsdk/src/main/java/io/getunleash/android/metrics/MetricsSender.kt#L77-L79 but not in the feature toggle fetcher.

Closes #99

## Discussion points
Maybe this can be refactored so the client of the throttler doesn't have to remember to call skipped. I have something like this in mind but it can be something good for a contribution, as I'm prioritizing fixing the bug.

```Kotlin
        return throttler.execute {
            Log.d(TAG, "Refreshing toggles")
            val response = doFetchToggles(ctx)
            fetcherHeartbeatFlow.emit(HeartbeatEvent(response.status, response.error?.message))
            return@execute response
        }.orElseGet {
            Log.i(TAG, "Skipping refresh toggles due to throttling")
            fetcherHeartbeatFlow.emit(HeartbeatEvent(Status.THROTTLED))
            return ToggleResponse(Status.THROTTLED)
        }
```
