### PR TITLE
chore: when releasing from main via GHA

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -39,3 +39,8 @@ jobs:
         if: github.event.inputs.release == 'patch'
       - run: ./gradlew release -Prelease.versionIncrementer=incrementPrerelease -Prelease.versionIncrementer.initialPreReleaseIfNotOnPrerelease=-rc1 -Prelease.ignoreChanges=true
         if: github.event.inputs.release == 'pre-release'
+
+  publish-release:
+    needs: create-tag
+    uses: ./.github/workflows/release.yaml
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,15 @@
 name: Publish SDK
 
 on:
+  # either if we push a tag manually or if it's called from create-release workflow
   push:
     tags:
       - 'v*'
-  workflow_run:
-    workflows: ["Create a new release tag"]
-    types:
-      - completed
+  workflow_call:
 
 jobs:
   deploy-release:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags')
     steps:
       - uses: actions/checkout@v4
         name: Checkout code


### PR DESCRIPTION
When releasing from main the action does not execute in the tag ref, therefore it's being ignored: https://github.com/Unleash/unleash-android/actions/runs/12805063978

With this the workflow that creates the tag will be calling the workflow that publishes the SDK