### PR TITLE
chore: configure publish to maven portal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingPassphrase: ${{ secrets.GPG_PASSPHRASE }}
         with:
           job-id: release
-          arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+          arguments: publishToMavenCentralPortal
       - name: Create Github release
         uses: actions/create-release@v1
         env:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,19 +3,4 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.jetbrains.kotlin.android) apply false
     alias(libs.plugins.android.library) apply false
-    id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
-}
-
-val sonatypeUsername: String? by project
-val sonatypePassword: String? by project
-
-nexusPublishing {
-    repositories {
-        sonatype {
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
-            username.set(sonatypeUsername)
-            password.set(sonatypePassword)
-        }
-    }
 }

--- a/unleashandroidsdk/build.gradle.kts
+++ b/unleashandroidsdk/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     id("org.jetbrains.dokka") version "1.9.20"
     id("pl.allegro.tech.build.axion-release") version "1.18.2"
     jacoco
+    id("tech.yanand.maven-central-publish").version("1.3.0")
 }
 
 val tagVersion = System.getenv("GITHUB_REF")?.split('/')?.last()
@@ -199,4 +200,12 @@ tasks.withType<Test> {
         excludes = listOf("jdk.internal.*")
     }
     finalizedBy(jacocoTestReport)
+}
+
+val mavenCentralToken: String? by project
+
+mavenCentral {
+    authToken = mavenCentralToken
+    publishingType = "AUTOMATIC"
+    maxWait = 120
 }


### PR DESCRIPTION
We got upgraded to the publishing portal this week (I upgraded us). This requires all our published project be published via the new portal. This PR configures https://github.com/yananhub/flying-gradle-plugin which should work (The needed api key has been added as a secret already)