### PR TITLE
fix: moves all local backup to IO context

### DIFF
--- a/unleashandroidsdk/src/test/java/io/getunleash/android/backup/LocalBackupTest.kt
+++ b/unleashandroidsdk/src/test/java/io/getunleash/android/backup/LocalBackupTest.kt
@@ -6,13 +6,11 @@ import io.getunleash.android.data.UnleashState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.awaitility.Awaitility.await
 import org.junit.Test
 import org.robolectric.shadows.ShadowLog
 import java.io.File
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeoutException
 import kotlin.io.path.createTempDirectory
 
 class LocalBackupTest : BaseTest() {


### PR DESCRIPTION
## About the changes
The only things done in the main thread are 

```kotlin
                val backupDir = CacheDirectoryProvider(unleashConfig.localStorageConfig, androidContext)
                    .getCacheDirectory(BACKUP_DIR_NAME)
                val localBackup = LocalBackup(backupDir)
```
Which shouldn't be CPU intensive, but because it involves verifying that the local directories exist, it may introduce some performance toll on the application. By moving those pieces into the IO context we should not see that impact anymore