### PR TITLE
fix: update local backup when local cache is empty

### DIFF
--- a/unleashandroidsdk/src/main/java/io/getunleash/android/DefaultUnleash.kt
+++ b/unleashandroidsdk/src/main/java/io/getunleash/android/DefaultUnleash.kt
@@ -172,6 +172,7 @@ class DefaultUnleash(
                 val backupDir = CacheDirectoryProvider(unleashConfig.localStorageConfig, androidContext)
                     .getCacheDirectory(BACKUP_DIR_NAME)
                 val localBackup = LocalBackup(backupDir)
+                localBackup.subscribeTo(cache.getUpdatesFlow())
                 unleashContextState.asStateFlow().takeWhile { !ready.get() }.collect { ctx ->
                     Log.d(TAG, "Loading state from backup for $ctx")
                     localBackup.loadFromDisc(unleashContextState.value)?.let { state ->
@@ -181,8 +182,6 @@ class DefaultUnleash(
                         } else {
                             Log.d(TAG, "Ignoring backup, Unleash is already ready")
                         }
-                        // subscribe to state changes after loading from backup
-                        localBackup.subscribeTo(cache.getUpdatesFlow())
                     }
                 }
             }


### PR DESCRIPTION
## Problem
- When no local cache exists, they did not update the local backup even after a successful API call.
- This behavior was due to subscribing to cache updates only after attempting to load from an existing local backup, which didn't exist.

## Solution
- Moved the `localBackup.subscribeTo(cache.getUpdatesFlow())` call **before** attempting to load the local cache.
- This ensures that the local backup is subscribed to cache updates immediately, regardless of whether a local cache file already exists.

## Context
- This bug was introduced by a recent change https://github.com/Unleash/unleash-android/pull/108

## Impact
- Ensures correct local backup functionality even on first launch or when the cache key not matching.

<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

<!-- Does it close an issue? Multiple? -->


<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
