### PR TITLE
feat: extract fun start() to unleash interface

### DIFF
--- a/unleashandroidsdk/src/main/java/io/getunleash/android/DefaultUnleash.kt
+++ b/unleashandroidsdk/src/main/java/io/getunleash/android/DefaultUnleash.kt
@@ -145,10 +145,10 @@ class DefaultUnleash(
         }
     }
 
-    fun start(
-        eventListeners: List<UnleashListener> = emptyList(),
-        bootstrapFile: File? = null,
-        bootstrap: List<Toggle> = emptyList()
+    override fun start(
+        eventListeners: List<UnleashListener>,
+        bootstrapFile: File?,
+        bootstrap: List<Toggle>
     ) {
         if (!started.compareAndSet(false, true)) {
             Log.w(TAG, "Unleash already started, ignoring start call")

--- a/unleashandroidsdk/src/main/java/io/getunleash/android/Unleash.kt
+++ b/unleashandroidsdk/src/main/java/io/getunleash/android/Unleash.kt
@@ -1,9 +1,11 @@
 package io.getunleash.android
 
+import io.getunleash.android.data.Toggle
 import io.getunleash.android.data.UnleashContext
 import io.getunleash.android.data.Variant
 import io.getunleash.android.events.UnleashListener
 import java.io.Closeable
+import java.io.File
 
 val disabledVariant = Variant("disabled")
 
@@ -70,4 +72,13 @@ interface Unleash: Closeable {
      * once the initial fetch of toggles has been completed or failed.
      */
     fun isReady(): Boolean
+
+    /**
+     * Starts Unleash manually
+     */
+    fun start(
+        eventListeners: List<UnleashListener> = emptyList(),
+        bootstrapFile: File? = null,
+        bootstrap: List<Toggle> = emptyList()
+    )
 }


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

<!-- Does it close an issue? Multiple? -->
Closes # https://github.com/Unleash/unleash-android-sdk/issues/132

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->

Maybe `bootstrapFile` parameter should not be exposed in `io.getunleash.android.Unleash#start` method, as it is only used in `io.getunleash.android.DefaultUnleash` (the only existing implementation of `io.getunleash.android.Unleash` interface) and better be passed as a constructor parameter. Same goes for `bootstrap` parameter but at least it is scoped as `io.getunleash.android.**` dependency.
